### PR TITLE
[TASK] Add dependencies to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,6 @@
     "description": "TYPO3 Cache Crippler",
     "type": "typo3-cms-extension",
     "require": {
-        "typo3/cms-core": "^7.6 || ^8.7 || ^9.4"
+        "typo3/cms-core": "^7.6 || ^8.7 || ^9.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,6 @@
     "description": "TYPO3 Cache Crippler",
     "type": "typo3-cms-extension",
     "require": {
-        "typo3/cms-core": "^7.6 || ^8.7 || ^9.5"
+        "typo3/cms-core": "^7.6 || ^8.7 || ^9.5 || ^10.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
     "name": "namelesscoder/uncache",
     "description": "TYPO3 Cache Crippler",
-    "type": "typo3-cms-extension"
+    "type": "typo3-cms-extension",
+    "require": {
+        "typo3/cms-core": "^7.6 || ^8.7 || ^9.4"
+    }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -34,7 +34,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'CGLcompliance_note' => '',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '7.6.0-9.5.99',
+			'typo3' => '7.6.0-10.4.99',
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
As per `./ext_emconf.php` this ext. is not working (official) with T3 v10. According to `./composer.json` there's no dependency. This adapts the dependencies from `./ext_emconf.php` to `./composer.json`